### PR TITLE
Silently drops keys that are too long for Blender objects

### DIFF
--- a/bpy_speckle/convert/__init__.py
+++ b/bpy_speckle/convert/__init__.py
@@ -97,7 +97,10 @@ def add_dictionary(prop, blender_object, superkey=None):
             if subtype and subtype in FROM_SPECKLE.keys():
                 continue
         else:
-            blender_object[key_name] = prop[key]
+            try:
+                blender_object[key_name] = prop[key]
+            except KeyError:
+                pass
 
 def add_custom_properties(speckle_object, blender_object):
 


### PR DESCRIPTION
Hi @tsvilans,

As discussed in https://discourse.speckle.works/t/long-key-names-in-blender/972, this adds a quick workaround to drop data with a key name that is too long for Blender. I'll try to get some more detailed info on the error next week.